### PR TITLE
fix linear conversion MACOS

### DIFF
--- a/Editor/Compute/RLBakeShader.compute
+++ b/Editor/Compute/RLBakeShader.compute
@@ -61,6 +61,8 @@
 #pragma kernel RLChannelPackLinear
 #pragma kernel RLChannelPackSymmetryLinear
 
+#pragma multi_compile _ _MAC_OS
+
 // Defines
 //
 #define SAMPLE(tex,coord) tex.SampleLevel (sampler##tex,coord, 0)
@@ -351,6 +353,8 @@ float4 LinearTosRGB(float4 In)
 {
 #ifdef UNITY_COLORSPACE_GAMMA    
     return In; 
+#elif _MAC_OS
+    return In;
 #else
     float3 sRGBLo = In.xyz * 12.92;
     float3 sRGBHi = (pow(max(abs(In.xyz), 1.192092896e-07), float3(1.0 / 2.4, 1.0 / 2.4, 1.0 / 2.4)) * 1.055) - 0.055;

--- a/Editor/ComputeBake.cs
+++ b/Editor/ComputeBake.cs
@@ -1914,6 +1914,13 @@ namespace Reallusion.Import
 
                 int kernel = bakeShader.FindKernel("RLChannelPackLinear");
                 bakeTarget.Create(bakeShader, kernel);
+
+				#if UNITY_STANDALONE_OSX
+					bakeShader.EnableKeyword("_MAC_OS");
+				#else
+					bakeShader.DisableKeyword("_MAC_OS");
+				#endif
+
                 bakeShader.SetTexture(kernel, "RedChannel", redChannel);
                 bakeShader.SetTexture(kernel, "GreenChannel", greenChannel);
                 bakeShader.SetTexture(kernel, "BlueChannel", blueChannel);
@@ -1950,6 +1957,13 @@ namespace Reallusion.Import
 
                 int kernel = bakeShader.FindKernel("RLChannelPackSymmetryLinear");
                 bakeTarget.Create(bakeShader, kernel);
+
+				#if UNITY_STANDALONE_OSX
+					bakeShader.EnableKeyword("_MAC_OS");
+				#else
+					bakeShader.DisableKeyword("_MAC_OS");
+				#endif
+
                 bakeShader.SetTexture(kernel, "RedChannelL", redChannelL);
                 bakeShader.SetTexture(kernel, "GreenChannelL", greenChannelL);
                 bakeShader.SetTexture(kernel, "BlueChannelL", blueChannelL);
@@ -2192,6 +2206,13 @@ namespace Reallusion.Import
                 cavityAO = CheckMask(cavityAO);
 
                 int kernel = bakeShader.FindKernel("RLHeadDiffuse");
+
+				#if UNITY_STANDALONE_OSX
+					bakeShader.EnableKeyword("_MAC_OS");
+				#else
+					bakeShader.DisableKeyword("_MAC_OS");
+				#endif
+
                 bakeTarget.Create(bakeShader, kernel);
                 bakeShader.SetTexture(kernel, "Diffuse", diffuse);
                 bakeShader.SetTexture(kernel, "ColorBlend", blend);
@@ -2432,6 +2453,13 @@ namespace Reallusion.Import
 
                 int kernel = bakeShader.FindKernel(kernelName);
                 bakeTarget.Create(bakeShader, kernel);
+
+				#if UNITY_STANDALONE_OSX
+					bakeShader.EnableKeyword("_MAC_OS");
+				#else
+					bakeShader.DisableKeyword("_MAC_OS");
+				#endif
+
                 bakeShader.SetTexture(kernel, "Subsurface", subsurface);
                 bakeShader.SetTexture(kernel, "NMUILMask", NMUIL);
                 bakeShader.SetTexture(kernel, "CFULCMask", CFULC);

--- a/Editor/ComputeBake.cs
+++ b/Editor/ComputeBake.cs
@@ -2206,6 +2206,7 @@ namespace Reallusion.Import
                 cavityAO = CheckMask(cavityAO);
 
                 int kernel = bakeShader.FindKernel("RLHeadDiffuse");
+                bakeTarget.Create(bakeShader, kernel);
 
 				#if UNITY_STANDALONE_OSX
 					bakeShader.EnableKeyword("_MAC_OS");
@@ -2213,7 +2214,6 @@ namespace Reallusion.Import
 					bakeShader.DisableKeyword("_MAC_OS");
 				#endif
 
-                bakeTarget.Create(bakeShader, kernel);
                 bakeShader.SetTexture(kernel, "Diffuse", diffuse);
                 bakeShader.SetTexture(kernel, "ColorBlend", blend);
                 bakeShader.SetTexture(kernel, "CavityAO", cavityAO);

--- a/Editor/ComputeBake.cs
+++ b/Editor/ComputeBake.cs
@@ -1915,11 +1915,10 @@ namespace Reallusion.Import
                 int kernel = bakeShader.FindKernel("RLChannelPackLinear");
                 bakeTarget.Create(bakeShader, kernel);
 
-				#if UNITY_STANDALONE_OSX
+				if (Application.platform == RuntimePlatform.OSXEditor)
 					bakeShader.EnableKeyword("_MAC_OS");
-				#else
+				else
 					bakeShader.DisableKeyword("_MAC_OS");
-				#endif
 
                 bakeShader.SetTexture(kernel, "RedChannel", redChannel);
                 bakeShader.SetTexture(kernel, "GreenChannel", greenChannel);
@@ -1958,11 +1957,10 @@ namespace Reallusion.Import
                 int kernel = bakeShader.FindKernel("RLChannelPackSymmetryLinear");
                 bakeTarget.Create(bakeShader, kernel);
 
-				#if UNITY_STANDALONE_OSX
+				if (Application.platform == RuntimePlatform.OSXEditor)
 					bakeShader.EnableKeyword("_MAC_OS");
-				#else
+				else
 					bakeShader.DisableKeyword("_MAC_OS");
-				#endif
 
                 bakeShader.SetTexture(kernel, "RedChannelL", redChannelL);
                 bakeShader.SetTexture(kernel, "GreenChannelL", greenChannelL);
@@ -2208,11 +2206,10 @@ namespace Reallusion.Import
                 int kernel = bakeShader.FindKernel("RLHeadDiffuse");
                 bakeTarget.Create(bakeShader, kernel);
 
-				#if UNITY_STANDALONE_OSX
+				if (Application.platform == RuntimePlatform.OSXEditor)
 					bakeShader.EnableKeyword("_MAC_OS");
-				#else
+				else
 					bakeShader.DisableKeyword("_MAC_OS");
-				#endif
 
                 bakeShader.SetTexture(kernel, "Diffuse", diffuse);
                 bakeShader.SetTexture(kernel, "ColorBlend", blend);
@@ -2454,11 +2451,10 @@ namespace Reallusion.Import
                 int kernel = bakeShader.FindKernel(kernelName);
                 bakeTarget.Create(bakeShader, kernel);
 
-				#if UNITY_STANDALONE_OSX
+				if (Application.platform == RuntimePlatform.OSXEditor)
 					bakeShader.EnableKeyword("_MAC_OS");
-				#else
+				else
 					bakeShader.DisableKeyword("_MAC_OS");
-				#endif
 
                 bakeShader.SetTexture(kernel, "Subsurface", subsurface);
                 bakeShader.SetTexture(kernel, "NMUILMask", NMUIL);


### PR DESCRIPTION
add _MAC_OS to Kernel to check if for Mac OS

Hi @soupday ,
I am not sure if this is the correct way. It worked for me. 
fixed this issue
https://github.com/soupday/cc_unity_tools_3D/issues/28

Thanks and regards
